### PR TITLE
fix: 在执行run函数时，不调用大模型

### DIFF
--- a/packages/vmind/src/atom/chartGenerator/spec/chartTypeUtils.ts
+++ b/packages/vmind/src/atom/chartGenerator/spec/chartTypeUtils.ts
@@ -34,8 +34,10 @@ const chartTypeMap: { [chartName: string]: string } = {
  * @returns
  */
 export const getVChartTypeByVmind = (type: string) => {
-  if (chartTypeMap[type]) {
-    return chartTypeMap[type];
+  const upperType = String(type).toUpperCase();
+  // 如果图形出现小写，则会报错。需要转换为大写
+  if (chartTypeMap[upperType]) {
+    return chartTypeMap[upperType];
   }
 
   return null;

--- a/packages/vmind/src/atom/dataInsight/algorithms/index.ts
+++ b/packages/vmind/src/atom/dataInsight/algorithms/index.ts
@@ -114,16 +114,18 @@ const revisedInsightByTypeMapping: Record<
 };
 
 export const getInsights = (context: DataInsightExtractContext, options: DataInsightOptions) => {
-  const { algorithms, maxNum, isLimitedbyChartType, detailMaxNum = [], language } = options;
+  const { algorithms, maxNum, isLimitedbyChartType, language } = options;
+  let { detailMaxNum = [] } = options;
   const { chartType, cell, spec, originDataset } = context;
   const insights: Insight[] = [];
   const insightAlgorithmContext = { ...context, insights };
   const isStack = isStackChart(spec, chartType, cell);
   const isPercent = isPercentChart(spec, chartType, cell);
 
-  algorithms.sort(
-    (a: string, b: string) => (algorithmMapping as any)[a].priority - (algorithmMapping as any)[b].priority
-  );
+  algorithms.sort((a: string, b: string) => {
+    return (algorithmMapping as any)?.[a]?.priority - (algorithmMapping as any)?.[b]?.priority;
+  });
+
   algorithms.forEach(key => {
     const algoInfo = algorithmMapping[key].info;
     const {
@@ -182,6 +184,21 @@ export const getInsights = (context: DataInsightExtractContext, options: DataIns
       : 1;
   });
   let afterLimitsInsights: Insight[] = [...revisedInsights];
+
+  //增加洞察兼容性处理
+  if (!detailMaxNum || detailMaxNum?.length == 0) {
+    detailMaxNum = [
+      {
+        types: ['outlier', 'pair_outlier', 'extreme_value', 'turning_point', 'majority_value'] as InsightType[],
+        maxNum: 3
+      },
+      { types: ['abnormal_band'] as InsightType[], maxNum: 3 },
+      { types: ['correlation'] as InsightType[], maxNum: 2 },
+      { types: ['overall_trend'] as InsightType[], maxNum: 2 },
+      { types: ['abnormal_trend'] as InsightType[], maxNum: 3 }
+    ];
+  }
+
   detailMaxNum.forEach(item => {
     const { types, maxNum } = item;
     const filteredInsights = revisedInsights.filter(insight => types.includes(insight.type)).slice(maxNum);

--- a/packages/vmind/src/atom/specInsight/index.ts
+++ b/packages/vmind/src/atom/specInsight/index.ts
@@ -160,6 +160,7 @@ export class SpecInsightAtom extends BaseAtom<SpecInsightCtx, SpecInsightOptions
   protected getMarkPointText(type: InsightType, value: string) {
     switch (type) {
       case InsightType.Min:
+        return value ? `Min: ${value}` : 'Min';
       case InsightType.Max:
         return value ? `${type}: ${value}` : type;
       case InsightType.TurningPoint:

--- a/packages/vmind/src/core/VMind.ts
+++ b/packages/vmind/src/core/VMind.ts
@@ -278,7 +278,7 @@ class VMind {
       [AtomName.IMAGE_READER]: !!image
     };
     const { chartType, chartAdvistorRes, spec, command, cell, vizSchema, dataTable, time, usage, error } =
-      await this.data2ChartSchedule.run(undefined, shouldRunList);
+      await this.data2ChartSchedule.run(userCommand, shouldRunList);  // 没有第一个参数，在执行run函数时，不会执行runWithChat，也就不会调用大模型
     return {
       chartType,
       spec,


### PR DESCRIPTION
### 🤔 这个分支是...

- Bug fix：没有第一个参数，在执行run函数时，不会执行runWithChat，也就不会调用大模型

### 💡 Background and solution

数据集
![image](https://github.com/user-attachments/assets/88bb132e-feb5-4095-9c9e-5c9ac506589b)

1、当我的prompt为： “只分析 事故数 指标”时，由于这个bug导致不走大模型，而是走了一个默认逻辑。导致所有指标全部显示
![image](https://github.com/user-attachments/assets/4088175f-27f6-4ce3-8300-c8fed83b5a02)
2、当修复bug后，只显示 事故数 指标。这才是想要的结果
![image](https://github.com/user-attachments/assets/dfd880b5-1098-470c-818b-38f8cd9e8694)

